### PR TITLE
fix: Bump to skar-client version 0.5.2 with decoding fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ anyhow = "1"
 
 serde_json = "1"
 
-skar-client = "0.5.1"
+skar-client = "0.5.2"
 skar-net-types = "0.1.1"
 skar-format = "0.2.0"
 


### PR DESCRIPTION
`skar-client = 0.5.1` doesn't have the decoding fix,  `0.5.2` does