### PR TITLE
(RFC) Add enums for field selection options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -105,10 +105,96 @@ export interface TransactionSelection {
   contractAddress?: Array<string>
 }
 export interface FieldSelection {
-  block?: Array<string>
-  transaction?: Array<string>
-  log?: Array<string>
-  trace?: Array<string>
+  block?: Array<BlockField>
+  transaction?: Array<TransactionField>
+  log?: Array<LogField>
+  trace?: Array<TraceField>
+}
+export const enum BlockField {
+  Number = 'Number',
+  Hash = 'Hash',
+  ParentHash = 'ParentHash',
+  Nonce = 'Nonce',
+  Sha3Uncles = 'Sha3Uncles',
+  LogsBloom = 'LogsBloom',
+  TransactionsRoot = 'TransactionsRoot',
+  StateRoot = 'StateRoot',
+  ReceiptsRoot = 'ReceiptsRoot',
+  Miner = 'Miner',
+  Difficulty = 'Difficulty',
+  TotalDifficulty = 'TotalDifficulty',
+  ExtraData = 'ExtraData',
+  Size = 'Size',
+  GasLimit = 'GasLimit',
+  GasUsed = 'GasUsed',
+  Timestamp = 'Timestamp',
+  Uncles = 'Uncles',
+  BaseFeePerGas = 'BaseFeePerGas'
+}
+export const enum TransactionField {
+  BlockHash = 'BlockHash',
+  BlockNumber = 'BlockNumber',
+  From = 'From',
+  Gas = 'Gas',
+  GasPrice = 'GasPrice',
+  Hash = 'Hash',
+  Input = 'Input',
+  Nonce = 'Nonce',
+  To = 'To',
+  TransactionIndex = 'TransactionIndex',
+  Value = 'Value',
+  V = 'V',
+  R = 'R',
+  S = 'S',
+  MaxPriorityFeePerGas = 'MaxPriorityFeePerGas',
+  MaxFeePerGas = 'MaxFeePerGas',
+  ChainId = 'ChainId',
+  CumulativeGasUsed = 'CumulativeGasUsed',
+  EffectiveGasPrice = 'EffectiveGasPrice',
+  GasUsed = 'GasUsed',
+  ContractAddress = 'ContractAddress',
+  LogsBloom = 'LogsBloom',
+  Type = 'Type',
+  Root = 'Root',
+  Status = 'Status',
+  Sighash = 'Sighash'
+}
+export const enum LogField {
+  Removed = 'Removed',
+  LogIndex = 'LogIndex',
+  TransactionIndex = 'TransactionIndex',
+  TransactionHash = 'TransactionHash',
+  BlockHash = 'BlockHash',
+  BlockNumber = 'BlockNumber',
+  Address = 'Address',
+  Data = 'Data',
+  Topic0 = 'Topic0',
+  Topic1 = 'Topic1',
+  Topic2 = 'Topic2',
+  Topic3 = 'Topic3'
+}
+export const enum TraceField {
+  From = 'From',
+  To = 'To',
+  CallType = 'CallType',
+  Gas = 'Gas',
+  Input = 'Input',
+  Init = 'Init',
+  Value = 'Value',
+  Author = 'Author',
+  RewardType = 'RewardType',
+  BlockHash = 'BlockHash',
+  BlockNumber = 'BlockNumber',
+  Address = 'Address',
+  Code = 'Code',
+  GasUsed = 'GasUsed',
+  Output = 'Output',
+  Subtraces = 'Subtraces',
+  TraceAddress = 'TraceAddress',
+  TransactionHash = 'TransactionHash',
+  TransactionPosition = 'TransactionPosition',
+  Kind = 'Kind',
+  Error = 'Error'
 }
 export interface TraceSelection {
   from?: Array<string>

--- a/index.js
+++ b/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { HexOutput, DataType, Decoder, presetQueryBlocksAndTransactions, presetQueryBlocksAndTransactionHashes, presetQueryLogs, presetQueryLogsOfEvent, JoinMode, HypersyncClient, QueryResponseStream, EventStream } = nativeBinding
+const { HexOutput, DataType, Decoder, presetQueryBlocksAndTransactions, presetQueryBlocksAndTransactionHashes, presetQueryLogs, presetQueryLogsOfEvent, BlockField, TransactionField, LogField, TraceField, JoinMode, HypersyncClient, QueryResponseStream, EventStream } = nativeBinding
 
 module.exports.HexOutput = HexOutput
 module.exports.DataType = DataType
@@ -319,6 +319,10 @@ module.exports.presetQueryBlocksAndTransactions = presetQueryBlocksAndTransactio
 module.exports.presetQueryBlocksAndTransactionHashes = presetQueryBlocksAndTransactionHashes
 module.exports.presetQueryLogs = presetQueryLogs
 module.exports.presetQueryLogsOfEvent = presetQueryLogsOfEvent
+module.exports.BlockField = BlockField
+module.exports.TransactionField = TransactionField
+module.exports.LogField = LogField
+module.exports.TraceField = TraceField
 module.exports.JoinMode = JoinMode
 module.exports.HypersyncClient = HypersyncClient
 module.exports.QueryResponseStream = QueryResponseStream

--- a/src/query.rs
+++ b/src/query.rs
@@ -47,13 +47,115 @@ pub struct TransactionSelection {
 #[derive(Default, Clone, Serialize, Deserialize)]
 pub struct FieldSelection {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub block: Option<Vec<String>>,
+    pub block: Option<Vec<BlockField>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub transaction: Option<Vec<String>>,
+    pub transaction: Option<Vec<TransactionField>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub log: Option<Vec<String>>,
+    pub log: Option<Vec<LogField>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub trace: Option<Vec<String>>,
+    pub trace: Option<Vec<TraceField>>,
+}
+
+#[napi(string_enum)]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BlockField {
+    Number,
+    Hash,
+    ParentHash,
+    Nonce,
+    Sha3Uncles,
+    LogsBloom,
+    TransactionsRoot,
+    StateRoot,
+    ReceiptsRoot,
+    Miner,
+    Difficulty,
+    TotalDifficulty,
+    ExtraData,
+    Size,
+    GasLimit,
+    GasUsed,
+    Timestamp,
+    Uncles,
+    BaseFeePerGas,
+}
+
+#[napi(string_enum)]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransactionField {
+    BlockHash,
+    BlockNumber,
+    From,
+    Gas,
+    GasPrice,
+    Hash,
+    Input,
+    Nonce,
+    To,
+    TransactionIndex,
+    Value,
+    V,
+    R,
+    S,
+    MaxPriorityFeePerGas,
+    MaxFeePerGas,
+    ChainId,
+    CumulativeGasUsed,
+    EffectiveGasPrice,
+    GasUsed,
+    ContractAddress,
+    LogsBloom,
+    Type,
+    Root,
+    Status,
+    Sighash,
+}
+
+#[napi(string_enum)]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LogField {
+    Removed,
+    LogIndex,
+    TransactionIndex,
+    TransactionHash,
+    BlockHash,
+    BlockNumber,
+    Address,
+    Data,
+    Topic0,
+    Topic1,
+    Topic2,
+    Topic3,
+}
+
+#[napi(string_enum)]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TraceField {
+    From,
+    To,
+    CallType,
+    Gas,
+    Input,
+    Init,
+    Value,
+    Author,
+    RewardType,
+    BlockHash,
+    BlockNumber,
+    Address,
+    Code,
+    GasUsed,
+    Output,
+    Subtraces,
+    TraceAddress,
+    TransactionHash,
+    TransactionPosition,
+    Kind,
+    Error,
 }
 
 #[napi(object)]


### PR DESCRIPTION
This is obviously a breaking change, but I think it's important that we make the field selection typed. Otherwise there is no help with what you should input.

What do you think?

My first prize would be if the string enums could be camelCase instead of PascalCase or snake_case (to be congruent with the field names returned in the js/ts library) but I can't see a simple way to do that.

Another option is to use a type overwrite: https://napi.rs/docs/concepts/types-overwrite#ts_type

but there is no clean way to do this with a union type since we also want the field to be optional.
