### PR TITLE
Update transaction field transaction_index to index

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -350,7 +350,7 @@ export interface Transaction {
   input?: string
   nonce?: bigint
   to?: string
-  transactionIndex?: number
+  index?: number
   value?: bigint
   v?: string
   r?: string

--- a/src/types.rs
+++ b/src/types.rs
@@ -51,7 +51,7 @@ pub struct Transaction {
     pub input: Option<String>,
     pub nonce: Option<BigInt>,
     pub to: Option<String>,
-    pub transaction_index: Option<i64>,
+    pub index: Option<i64>,
     pub value: Option<BigInt>,
     pub v: Option<String>,
     pub r: Option<String>,
@@ -341,7 +341,7 @@ impl Transaction {
             input: map_hex_string(&t.input),
             nonce: map_bigint(&t.nonce),
             to: map_address_string(&t.to, should_checksum),
-            transaction_index: t
+            index: t
                 .transaction_index
                 .map(|n| u64::from(n).try_into())
                 .transpose()


### PR DESCRIPTION
The request was made in the indexer that the "transactionIndex" field be changed to "index" so that while referencing it reads like:

```ts
event.transaction.index
```

instead of 
```ts
event.transaction.transactionIndex
```

What do you think @ozgrakkurt? I know this may be inconsistent with field names on an rpc response. I don't have a strong opinion either way. It will read nicely in the indexer code though.