### PR TITLE
Rename kind field to type on serde

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -120,6 +120,7 @@ pub enum TransactionField {
     GasUsed,
     ContractAddress,
     LogsBloom,
+    #[serde(rename = "type")]
     Kind,
     Root,
     Status,


### PR DESCRIPTION
Currently the "kind" field does not actually pass the correct value to field selection.

And you can't just pass "type" directly in js because then napi does not allow it. 