### PR TITLE
Upgrade native bindings to v1.3.0 and add setLogLevel export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -89,6 +89,10 @@ export declare class HypersyncClient {
   get(query: Query): Promise<QueryResponse>
   /** Get blockchain events for a single query */
   getEvents(query: Query): Promise<EventResponse>
+  /** Stream chain height events */
+  streamHeight(): Promise<HeightStream>
+  /** Stream blockchain data from the given query */
+  stream(query: Query, config: StreamConfig): Promise<QueryResponseStream>
   /** Get blockchain data for a single query, with rate limit info */
   getWithRateLimit(query: Query): Promise<QueryResponseWithRateLimit>
   /**
@@ -101,10 +105,6 @@ export declare class HypersyncClient {
    * Returns immediately if no rate limit info observed or quota available.
    */
   waitForRateLimit(): Promise<void>
-  /** Stream chain height events */
-  streamHeight(): Promise<HeightStream>
-  /** Stream blockchain data from the given query */
-  stream(query: Query, config: StreamConfig): Promise<QueryResponseStream>
   /** Stream blockchain events from the given query */
   streamEvents(query: Query, config: StreamConfig): Promise<EventStream>
 }
@@ -575,26 +575,6 @@ export interface Query {
   joinMode?: JoinMode
 }
 
-/** Rate limit information from server response headers. */
-export interface RateLimitInfo {
-  /** Total request quota for the current window. */
-  limit?: number
-  /** Remaining budget in the current window. */
-  remaining?: number
-  /** Seconds until the rate limit window resets. */
-  resetSecs?: number
-  /** Budget consumed per request. */
-  cost?: number
-}
-
-/** Response from a query that includes rate limit information. */
-export interface QueryResponseWithRateLimit {
-  /** The query response data. */
-  response: QueryResponse
-  /** Rate limit information from response headers. */
-  rateLimit: RateLimitInfo
-}
-
 /** Response from a blockchain query */
 export interface QueryResponse {
   /** Current height of the source hypersync instance */
@@ -625,6 +605,26 @@ export interface QueryResponseData {
   traces: Array<Trace>
 }
 
+/** Response from a query that includes rate limit information. */
+export interface QueryResponseWithRateLimit {
+  /** The query response data. */
+  response: QueryResponse
+  /** Rate limit information from response headers. */
+  rateLimit: RateLimitInfo
+}
+
+/** Rate limit information from server response headers. */
+export interface RateLimitInfo {
+  /** Total request quota for the current window. */
+  limit?: number
+  /** Remaining budget in the current window. */
+  remaining?: number
+  /** Seconds until the rate limit window resets. */
+  resetSecs?: number
+  /** Budget consumed per request. */
+  cost?: number
+}
+
 export type ReconnectingTag =  'Reconnecting';
 
 export interface RollbackGuard {
@@ -653,6 +653,17 @@ export type SerializationFormat = /** Use JSON serialization (default) */
 'Json'|
 /** Use Cap'n Proto binary serialization */
 'CapnProto';
+
+/**
+ * Set the log level for the underlying Rust logger.
+ *
+ * Accepts values like "info", "warn", "debug", "trace", "error",
+ * or a full filter directive like "hypersync_client=debug".
+ * If RUST_LOG env var is set, it takes precedence.
+ * Must be called before creating any HypersyncClient.
+ * Only the first call takes effect (logger can only init once per process).
+ */
+export declare function setLogLevel(level: string): void
 
 /** Config for hypersync event streaming. */
 export interface StreamConfig {

--- a/index.js
+++ b/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@envio-dev/hypersync-client-android-arm64')
         const bindingPackageVersion = require('@envio-dev/hypersync-client-android-arm64/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@envio-dev/hypersync-client-android-arm-eabi')
         const bindingPackageVersion = require('@envio-dev/hypersync-client-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@envio-dev/hypersync-client-win32-x64-gnu')
         const bindingPackageVersion = require('@envio-dev/hypersync-client-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@envio-dev/hypersync-client-win32-x64-msvc')
         const bindingPackageVersion = require('@envio-dev/hypersync-client-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@envio-dev/hypersync-client-win32-ia32-msvc')
         const bindingPackageVersion = require('@envio-dev/hypersync-client-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@envio-dev/hypersync-client-win32-arm64-msvc')
         const bindingPackageVersion = require('@envio-dev/hypersync-client-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@envio-dev/hypersync-client-darwin-universal')
       const bindingPackageVersion = require('@envio-dev/hypersync-client-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@envio-dev/hypersync-client-darwin-x64')
         const bindingPackageVersion = require('@envio-dev/hypersync-client-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@envio-dev/hypersync-client-darwin-arm64')
         const bindingPackageVersion = require('@envio-dev/hypersync-client-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@envio-dev/hypersync-client-freebsd-x64')
         const bindingPackageVersion = require('@envio-dev/hypersync-client-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@envio-dev/hypersync-client-freebsd-arm64')
         const bindingPackageVersion = require('@envio-dev/hypersync-client-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@envio-dev/hypersync-client-linux-x64-musl')
           const bindingPackageVersion = require('@envio-dev/hypersync-client-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@envio-dev/hypersync-client-linux-x64-gnu')
           const bindingPackageVersion = require('@envio-dev/hypersync-client-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@envio-dev/hypersync-client-linux-arm64-musl')
           const bindingPackageVersion = require('@envio-dev/hypersync-client-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@envio-dev/hypersync-client-linux-arm64-gnu')
           const bindingPackageVersion = require('@envio-dev/hypersync-client-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@envio-dev/hypersync-client-linux-arm-musleabihf')
           const bindingPackageVersion = require('@envio-dev/hypersync-client-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@envio-dev/hypersync-client-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@envio-dev/hypersync-client-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@envio-dev/hypersync-client-linux-loong64-musl')
           const bindingPackageVersion = require('@envio-dev/hypersync-client-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@envio-dev/hypersync-client-linux-loong64-gnu')
           const bindingPackageVersion = require('@envio-dev/hypersync-client-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@envio-dev/hypersync-client-linux-riscv64-musl')
           const bindingPackageVersion = require('@envio-dev/hypersync-client-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@envio-dev/hypersync-client-linux-riscv64-gnu')
           const bindingPackageVersion = require('@envio-dev/hypersync-client-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@envio-dev/hypersync-client-linux-ppc64-gnu')
         const bindingPackageVersion = require('@envio-dev/hypersync-client-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@envio-dev/hypersync-client-linux-s390x-gnu')
         const bindingPackageVersion = require('@envio-dev/hypersync-client-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@envio-dev/hypersync-client-openharmony-arm64')
         const bindingPackageVersion = require('@envio-dev/hypersync-client-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@envio-dev/hypersync-client-openharmony-x64')
         const bindingPackageVersion = require('@envio-dev/hypersync-client-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@envio-dev/hypersync-client-openharmony-arm')
         const bindingPackageVersion = require('@envio-dev/hypersync-client-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -591,5 +591,6 @@ module.exports.presetQueryLogs = nativeBinding.presetQueryLogs
 module.exports.presetQueryLogsOfEvent = nativeBinding.presetQueryLogsOfEvent
 module.exports.ReconnectingTag = nativeBinding.ReconnectingTag
 module.exports.SerializationFormat = nativeBinding.SerializationFormat
+module.exports.setLogLevel = nativeBinding.setLogLevel
 module.exports.TraceField = nativeBinding.TraceField
 module.exports.TransactionField = nativeBinding.TransactionField

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envio-dev/hypersync-client-darwin-arm64",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "cpu": [
     "arm64"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envio-dev/hypersync-client-darwin-x64",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "cpu": [
     "x64"
   ],

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envio-dev/hypersync-client-linux-arm64-gnu",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "cpu": [
     "arm64"
   ],

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envio-dev/hypersync-client-linux-x64-gnu",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "cpu": [
     "x64"
   ],

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envio-dev/hypersync-client-linux-x64-musl",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "cpu": [
     "x64"
   ],


### PR DESCRIPTION
## Summary
This PR updates the hypersync-client native bindings from v1.2.0 to v1.3.0 across all supported platforms and adds a new `setLogLevel` function export to the public API.

## Key Changes
- **Version bump**: Updated all native binding package versions from 1.2.0 to 1.3.0 in `index.js` version checks for all 26 supported platform/architecture combinations
- **New API export**: Added `setLogLevel` function export in `index.js` to expose the underlying Rust logger configuration
- **Type definitions**: Added TypeScript declaration for `setLogLevel(level: string)` function with documentation explaining its usage and constraints
- **Method reordering**: Reorganized `HypersyncClient` class methods in type definitions to group streaming methods together (`streamHeight` and `stream` moved before `getWithRateLimit`)
- **Interface reordering**: Reordered type definitions in `index.d.ts` to place `QueryResponseWithRateLimit` and `RateLimitInfo` after `QueryResponseData` for better logical grouping

## Implementation Details
- The `setLogLevel` function accepts log level strings like "info", "warn", "debug", "trace", "error" or full filter directives like "hypersync_client=debug"
- The function must be called before creating any `HypersyncClient` instances
- Only the first call takes effect as the logger can only be initialized once per process
- The RUST_LOG environment variable takes precedence if set

https://claude.ai/code/session_012S4bi3pn9iQ8aT9iMv4s5i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v1.3.0

* **New Features**
  * Added `setLogLevel(level: string)` function to configure logging before initializing the client.

* **Chores**
  * Updated package version to 1.3.0 across all platform distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->