### PR TITLE
Report the real package version in the user agent (hscn/<version>)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,4 +2,28 @@ extern crate napi_build;
 
 fn main() {
     napi_build::setup();
+
+    // Expose the npm package version (from package.json) so the client can report
+    // it in its user agent. The Cargo package version is kept at 0.0.0 by napi, so
+    // CARGO_PKG_VERSION is not usable here. The release artifacts are built via
+    // `yarn build` from a checkout whose package.json holds the release version,
+    // so reading it here picks up the real version regardless of the build env.
+    // Falls back to CARGO_PKG_VERSION if package.json can't be read.
+    let version = std::fs::read_to_string("package.json")
+        .ok()
+        .and_then(|pkg| {
+            pkg.lines().find_map(|line| {
+                line.trim()
+                    .strip_prefix("\"version\":")
+                    .map(|rest| {
+                        rest.trim()
+                            .trim_matches(|c| c == ',' || c == '"' || c == ' ')
+                            .to_string()
+                    })
+            })
+        })
+        .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
+
+    println!("cargo:rustc-env=NPM_PKG_VERSION={version}");
+    println!("cargo:rerun-if-changed=package.json");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,9 @@ impl HypersyncClient {
     /// Create a new client with given config
     #[napi(constructor)]
     pub fn new(cfg: ClientConfig) -> napi::Result<HypersyncClient> {
-        Self::new_with_agent(cfg, format!("hscn/{}", env!("CARGO_PKG_VERSION")))
+        // NPM_PKG_VERSION is the package.json version, injected by build.rs.
+        // (CARGO_PKG_VERSION is 0.0.0 because napi keeps the Cargo version static.)
+        Self::new_with_agent(cfg, format!("hscn/{}", env!("NPM_PKG_VERSION")))
     }
 
     /// Create a new client with custom user agent


### PR DESCRIPTION
The client already tags requests with `hscn/<version>`, but the version came from `CARGO_PKG_VERSION` — and napi keeps the Cargo package version pinned at `0.0.0`, so every request actually went out as **`hscn/0.0.0`**.

This makes `build.rs` read the version from `package.json` and inject it as `NPM_PKG_VERSION`, which the client now uses → `hscn/<package-version>` (e.g. `hscn/1.4.0`).

### Why the release gets the right version
`build.rs` reads `package.json` **directly**, not via any build-time env var the pipeline may or may not set. The publish workflow (`publish_to_npm.yaml`) builds each platform with `checkout` → `yarn install` → `yarn build`, so the artifact is compiled from a checkout whose `package.json` holds the release version (kept in sync by `napi version`). It falls back to `CARGO_PKG_VERSION` only if `package.json` can't be read.

Matches the Rust (`hscr/`) and Python (`hscp/`, separate PR) clients. Verified with `cargo check` (the `env!("NPM_PKG_VERSION")` would fail to compile if build.rs didn't set it; the version parses to 1.4.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build process to extract and synchronize the npm package version with Rust at build time
  * Modified API client initialization to use the npm package version
  * Configured package.json as a build dependency tracker to ensure version consistency across platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->